### PR TITLE
macOS compilation issue 

### DIFF
--- a/src/lmc.cpp
+++ b/src/lmc.cpp
@@ -15,6 +15,16 @@
 // disable omp pragma warnings
 #ifdef WIN32
 #pragma warning (disable : 4068 )
+#elif defined(__APPLE__)
+#pragma warning (disable : 4068 )
+
+bool operator!= (symmdataPointer const& ptr, int x)
+{
+    // A friendly reminder to not test pointers against any values except 0 (NULL)
+    myassert(!x);
+    return ptr;
+}
+
 #else
 // http://choorucode.com/2014/03/11/how-to-ignore-specific-warning-of-gcc/
 //#pragma GCC diagnostic ignored "-Wno-unknown-pragmas"

--- a/src/lmc.h
+++ b/src/lmc.h
@@ -353,6 +353,23 @@ inline array_link rootPlus(const arraydata_t &ad)
 #include <memory>
 typedef std::shared_ptr<symmdata> symmdataPointer;
 //typedef std::shared_ptr<symmdata> symmdataPointer;
+
+#elif defined(__APPLE__)
+
+#include <memory>
+typedef std::shared_ptr<symmdata> symmdataPointer;
+
+/** @brief An operator to test whether a pointer holds a null value or not
+ *
+ * It is recomended to not compare pointers to integers and use explicit
+ * conversion `ptr to bool` instead or as another approach to compare pointers against
+ * nullptr which has type of std::nullptr. But such methods would force migration to C++11. Hence,
+ * the purpose of this method is to avoid ether rewritting the whole project or changing the code
+ * that already works on other platforms (aka Windows) by adding a missing in <memory> header
+ * comparison `bool operator!=(smart_ptr, int)`
+ */
+bool operator!= (symmdataPointer const& ptr, int x);
+
 #else
 #include <tr1/memory>
 typedef std::tr1::shared_ptr<symmdata> symmdataPointer;


### PR DESCRIPTION
Reopening pr https://github.com/eendebakpt/oapackage/pull/5

It was my bad that in previous pr I had modified windows code as well as macOS one. Now all changes are guarded with macros and should not cause any troubles.

Unfortunately, I can not test build on win32 nor win64 but it seems to me that there is some possibility that the same problem I faced on macOS when `<memory>` is included (missing comparison operator), might be on win32 platform as well.