### PR TITLE
attempt at fix

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -80,7 +80,7 @@ year={2018}
   author       = {{R Core Team}},
   organization = {R Foundation for Statistical Computing},
   address      = {Vienna, Austria},
-  year         = YEAR,
+  year         = {n.y.},
   url          = {https://www.R-project.org}
 }
 


### PR DESCRIPTION
better would be to leave this blank:   year = {},
but if that doesn't work, which I guess might be the case, n.y. as an abbreviation for no year is better than YEAR