### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Acknowledgements
 
 If you use this code or any of the results, please cite this program as follows:
 
-* [Complete Enumeration of Pure-Level and Mixed-Level Orthogonal Arrays](http://dx.doi.org/10.1002/jcd.20236), E.D. Schoen, P.T. Eendebak, M.V.M. Nguyen, Volume 18, Issue 2, pages 123-140, 2010.
+* [Complete Enumeration of Pure-Level and Mixed-Level Orthogonal Arrays](https://doi.org/10.1002/jcd.20236), E.D. Schoen, P.T. Eendebak, M.V.M. Nguyen, Volume 18, Issue 2, pages 123-140, 2010.
 * [Two-Level Designs to Estimate All Main Effects and Two-Factor Interactions](https://doi.org/10.1080/00401706.2016.1142903), Pieter T. Eendebak, Eric D. Schoen, Technometrics Vol. 59 , Iss. 1, 2017
 
 The code was written by:

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -91,8 +91,8 @@ note={Published online}
   pages = {69-79},
   volume = {59},
   doi = {10.1080/00401706.2016.1142903},
-  eprintx = { http://dx.doi.org/10.1080/00401706.2016.1142903},
-  url = {http://dx.doi.org/10.1080/00401706.2016.1142903},
+  eprintx = { https://doi.org/10.1080/00401706.2016.1142903},
+  url = {https://doi.org/10.1080/00401706.2016.1142903},
 }
 
 @misc{EendebakOA,
@@ -127,8 +127,8 @@ url={http://www.pietereendebak.nl/oapage/index-evenodd.html}
   pages = {69-79},
   volume = {59},
   doi = {10.1080/00401706.2016.1142903},
-  eprintx = { http://dx.doi.org/10.1080/00401706.2016.1142903},
-  url = {http://dx.doi.org/10.1080/00401706.2016.1142903},
+  eprintx = { https://doi.org/10.1080/00401706.2016.1142903},
+  url = {https://doi.org/10.1080/00401706.2016.1142903},
 }
 
 @ARTICLE{Balakrishnan2006,
@@ -221,7 +221,7 @@ url={http://www.pietereendebak.nl/oapage/index-evenodd.html}
   keywords = {Estimation capacity, Resolution, Suspect two-factor interaction, Upper
 	weak majorization, Word length pattern},
   publisher = {Blackwell Publishers Ltd.},
-  url = {http://dx.doi.org/10.1111/1467-9868.00164}
+  url = {https://doi.org/10.1111/1467-9868.00164}
 }
 
 @ARTICLE{Clark2001,
@@ -542,7 +542,7 @@ pages={45--87}
   keywords = {experimental design, isomorphism, asymmetric array, symmetric array},
   publisher = {Wiley Subscription Services, Inc., A Wiley Company},
   url = {files/JCDarticleR2.pdf},
-  urlx = {http://dx.doi.org/10.1002/jcd.20236}
+  urlx = {https://doi.org/10.1002/jcd.20236}
 }
 
 @ARTICLE{Schur1917,

--- a/oapackage/Doptim.py
+++ b/oapackage/Doptim.py
@@ -264,7 +264,7 @@ def generateDpage(outputdir, arrayclass, dds, allarrays, fig=20, optimfunc=[1, 0
              style="margin: 10px; width:95%; min-width: 300px;  max-width:1100px; height: auto; ")
 
     citationstr = markup.oneliner.a(
-        'Complete Enumeration of Pure-Level and Mixed-Level Orthogonal Arrays', href='http://dx.doi.org/10.1002/jcd.20236')
+        'Complete Enumeration of Pure-Level and Mixed-Level Orthogonal Arrays', href='https://doi.org/10.1002/jcd.20236')
 
     page.br(clear='both')
     page.p(
@@ -487,7 +487,7 @@ def Doptimize(arrayclass, nrestarts=10, optimfunc=[
 
     The optimization target and the Pareto optimality are defined in terms of the D-efficiency, main effect robustness
     (or Ds-optimality) and the D1-efficiency of the design. For more details see the paper "Two-Level Designs to Estimate All Main
-    Effects and Two-Factor Interactions", http://dx.doi.org/10.1080/00401706.2016.1142903
+    Effects and Two-Factor Interactions", https://doi.org/10.1080/00401706.2016.1142903
 
     Args:
       arrayclass (object): Specifies the type of design to optimize

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -36,8 +36,8 @@ note={Published online}
   pages = {69-79},
   volume = {59},
   doi = {10.1080/00401706.2016.1142903},
-  eprintx = { http://dx.doi.org/10.1080/00401706.2016.1142903},
-  url = {http://dx.doi.org/10.1080/00401706.2016.1142903},
+  eprintx = { https://doi.org/10.1080/00401706.2016.1142903},
+  url = {https://doi.org/10.1080/00401706.2016.1142903},
 }
 
 @misc{EendebakDOF,
@@ -60,7 +60,7 @@ note={Published online}
   keywords = {experimental design, isomorphism, asymmetric array, symmetric array},
   publisher = {Wiley Subscription Services, Inc., A Wiley Company},
   url = {files/JCDarticleR2.pdf},
-  urlx = {http://dx.doi.org/10.1002/jcd.20236}
+  urlx = {https://doi.org/10.1002/jcd.20236}
 }
 
 
@@ -99,7 +99,7 @@ number = {3},
 pages = {589-602},
 year = {1995},
 doi = {10.1093/biomet/82.3.589},
-URL = {http://dx.doi.org/10.1093/biomet/82.3.589},
+URL = {https://doi.org/10.1093/biomet/82.3.589},
 eprint = {/oup/backfile/content_public/journal/biomet/82/3/10.1093/biomet/82.3.589/2/82-3-589.pdf}
 }
 

--- a/src/Deff.h
+++ b/src/Deff.h
@@ -66,7 +66,7 @@ struct DoptimReturn {
  * The optimization is performed multiple times to prevent finding a design in a local minmum of the target function.
  *
  * The method is described in more detail in "Two-Level Designs to Estimate All Main Effects and Two-Factor Interactions",
- * Eendebak et al., 2015, Technometrics, http://dx.doi.org/10.1080/00401706.2016.1142903.
+ * Eendebak et al., 2015, Technometrics, https://doi.org/10.1080/00401706.2016.1142903.
  *
  * \param arrayclass Class of designs to optimize
  * \param nrestarts Number of restarts to perform


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

I'd simply like to suggest to update all static DOI links accordingly.

Cheers!