### PR TITLE
Feature: remove MPI code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,6 @@ if (NumPy_FOUND)
   message(STATUS "NumPy was found")
 endif()
 
-# find_package(MPI)	# Needed for legacy code and OpenMP functionality
 
 # ----------------------------------------------------------------------------
 #   Code
@@ -233,39 +232,6 @@ endif()
 
   TARGET_LINK_LIBRARIES(oaextendsingle oalib)
   set(extendprogs oaextendsingle )
-
-  if (MPI_FOUND AND NOT WIN32 AND 1)
-    message(STATUS "Found MPI package: adding oaextendmpi")
-    if (VERBOSE)
-	message(STATUS "MPI executable: ${MPIEXEC}, libs ${MPI_LIBRARIES}")
-    endif()
-    #message(STATUS "   libs ${MPI_LIBRARIES}; flags ${MPI_COMPILE_FLAGS}; libs ${MPI_LIBRARIES}")
-    include_directories( ${MPI_INCLUDE_PATH} )
-    include_directories( src/mpitools )
-
-  add_executable(oaextendmpi EXCLUDE_FROM_ALL "utils/oaextend.cpp" ${headersextend} ${srcsextend} "src/mpitools/mpitools.cpp")
-  target_link_libraries(oaextendmpi ${MPI_LIBRARIES})
-  if(MPI_COMPILE_FLAGS)
-    set_target_properties(oaextendmpi PROPERTIES COMPILE_FLAGS "${MPI_COMPILE_FLAGS}")
-  endif()
-  if(MPI_LINK_FLAGS)
-      if (WIN32)
-		set_target_properties(oaextendmpi PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS} /MT")
-		endif()
-    set_target_properties(oaextendmpi PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS}")
-  endif()
-
-  set_target_properties(oaextendmpi PROPERTIES COMPILE_DEFINITIONS "OAEXTEND_MULTICORE;NEWINTERFACE" )
-
-   if (WIN32)
-    if(ZLIB_FOUND)
-      TARGET_LINK_LIBRARIES(oaextendmpi ${ZLIB_LIBRARIES})
-    endif()
-   else()
-      TARGET_LINK_LIBRARIES(oaextendmpi m ${ZLIB_LIBRARIES})
-   endif()
-
-  endif(MPI_FOUND AND NOT WIN32 AND 1)
 
 message(STATUS "Extend progs: ${extendprogs}")
 

--- a/src/arraytools.h
+++ b/src/arraytools.h
@@ -116,7 +116,6 @@ typedef const short int carray_t;
 
 /* change definition below together with array_t !!!! */
 #define MPI_ARRAY_T MPI_SHORT
-/*other options for MPI_ARRAY_T are: char: MPI_CHAR, short: MPI_SHORT, int: MPI_INT, long: MPI_LONG */
 
 typedef short int rowindex_t;       /** type used for row indexing */
 typedef int colindex_t;             /** type used for column indexing */

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -1,6 +1,4 @@
-#ifdef OAEXTEND_MULTICORE
-#include <mpi.h>
-#endif
+
 #include <algorithm>
 #include <errno.h>
 #include <list>
@@ -847,11 +845,7 @@ int extend_array (const array_link &input_array, const arraydata_t *fullad, cons
 #endif
 
         const rowindex_t N = p->ad->N;
-#ifdef OAEXTEND_MULTICORE
-        const int node_rank = MPI::COMM_WORLD.Get_rank ();
-#else
         const int node_rank = 0;
-#endif
 
         LMCreduction_t reduction (ad);
         reduction.init_state = COPY;

--- a/src/extend.h
+++ b/src/extend.h
@@ -6,9 +6,6 @@
 #ifndef EXTEND_H
 #define EXTEND_H
 
-#ifdef OAEXTEND_MULTICORE
-#include <mpi.h>
-#endif
 #include "arraytools.h"
 #include "lmc.h"
 #include "oaoptions.h"

--- a/src/lmc.cpp
+++ b/src/lmc.cpp
@@ -1441,7 +1441,10 @@ std::vector< int > symmetrygroup2splits (const symmetry_group &sg, int ncols, in
         return splits;
 }
 
-void _calculate_j4_values(std::vector<int> &j4_values, carray_t *array, const int N, const colperm_t comb)
+/** Calculate J4 values for all delete-one-factor combinations of the specified comb 5-column combination
+ *
+*/
+void _calculate_dof_j4_values(std::vector<int> &j4_values, carray_t *array, const int N, const colperm_t comb)
 {
 	colindex_t lc[4];
 	init_perm(lc, 4);
@@ -1471,8 +1474,7 @@ int jj45split (carray_t *array, rowindex_t N, int jj, const colperm_t comb, cons
         // allocate buffer to hold the values
         std::vector< int > j4_values (5);
 
-        /* calculate the J4 values */
-		_calculate_j4_values(j4_values, array, N, comb);
+		_calculate_dof_j4_values(j4_values, array, N, comb);
 
         indexsort s (5);
         s.sort (j4_values);
@@ -1489,12 +1491,7 @@ int jj45split (carray_t *array, rowindex_t N, int jj, const colperm_t comb, cons
 
         // create the sorted column combination
         perform_inv_perm (comb, comby, jj, s.indices);
-        if (verbose >= 2) {
-                myprintf ("initial comb: ");
-                print_perm (comb, jj);
-                myprintf (" result comb: ");
-                print_perm (comby, jj);
-        }
+
         // make splits
         init_perm (perm, ad.ncols);
         create_perm_from_comb2< colindex_t > (perm, comby, jj, ad.ncols);
@@ -1689,7 +1686,7 @@ lmc_t LMCcheckj5 (array_link const &al, arraydata_t const &adin, LMCreduction_t 
 
         lmc_t ret = LMC_EQUAL;
 
-        /* loop over all possible column combinations for the first jj columns */
+        /* calculate invariants for the first jj columns */
         int jbase = abs (jvaluefast (array, ad.N, jj, firstcolcomb));
         jj45_t j54_base = jj45val (array, ad.N, firstcolcomb, 0);
 


### PR DESCRIPTION
The MPI code has not been used for years, and there are better alternatives (e.g. split into blocks using the python interface).
